### PR TITLE
Minor erlsha2:init/0 improvement

### DIFF
--- a/src/erlsha2.erl
+++ b/src/erlsha2.erl
@@ -192,12 +192,7 @@ init() ->
     SoName = filename:join(case code:priv_dir(?MODULE) of
                                {error, bad_name} ->
                                    %% this is here for testing purposes
-                                   case file:read_file_info("./priv") of
-                                       {error, _} ->
-                                           "../priv";
-                                       _ ->
-                                           "./priv"
-                                   end;
+                                   filename:join([filename:dirname(code:which(?MODULE)),"..","priv"]);
                                Dir ->
                                    Dir
                            end, atom_to_list(?MODULE) ++ "_nif"),


### PR DESCRIPTION
Instead of guess where priv is (which is prone to failure anyway, what if I did erl -pa /somewhere/else/erlsha2/ebin?) just interpolate it from code:which(?MODULE) path
