### PR TITLE
Code change for new rebar

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- erlang -*-
-{so_specs, [{"priv/erlsha2_nif.so", ["c_src/erlsha2_nif.c"]}]}.
+{port_specs, [{"priv/erlsha2_nif.so", ["c_src/erlsha2_nif.c"]}]}.
 
 {port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -O3 -I."},
             {"linux.*-32$", "CFLAGS", "-m32"},


### PR DESCRIPTION
rebar.config needs port_specs for new rebar; a commit was merged in 2 days ago which reverted your older fixes back to the old so_specs terminology.
