### PR TITLE
fix erlsha2 on arm platforms

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,10 +2,10 @@
 {port_specs, [{"priv/erlsha2_nif.so", ["c_src/erlsha2_nif.c"]}]}.
 
 {port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -O3 -I."},
-            {"linux.*-32$", "CFLAGS", "-m32"},
-            {"linux.*-32$", "LDFLAGS", "-m32"},
-            {"linux.*-64$", "CFLAGS", "-m64"},
-            {"linux.*-64$", "LDFLAGS", "-m64"}]}.
+            {"(?<!-arm)-[^-]+-linux.*-32$", "CFLAGS", "-m32"},
+            {"(?<!-arm)-[^-]+-linux.*-32$", "LDFLAGS", "-m32"},
+            {"(?<!-arm)-[^-]+-linux.*-64$", "CFLAGS", "-m64"},
+            {"(?<!-arm)-[^-]+-linux.*-64$", "LDFLAGS", "-m64"}]}.
 
 {pre_hooks, [{compile, "c_src/config.sh c_src/config.h"},
              {clean, "rm -f c_src/config.h"}]}.


### PR DESCRIPTION
-m32 is not a valid gcc param on arm, so on arm we need to not include it in the CFLAGS
