### PR TITLE
Use erlang:nif_error/1 to fix dialyzer warning

### DIFF
--- a/src/hmac.erl
+++ b/src/hmac.erl
@@ -95,7 +95,7 @@ hexlify(Binary, Opts) when is_binary(Binary), is_list(Opts) ->
     hexlify_nif(Binary, Flags).
 
 hexlify_nif(_Bin, _Opts) ->
-    {error, nif_not_loaded}.
+    erlang:nif_error(nif_not_loaded).
 
 %% @spec hmac224(key(), data()) -> mac()
 %% where


### PR DESCRIPTION
Generating an exception in the nif stub function makes dialyzer happy. However, this would break code that relies on the {error, nif_not_loaded} tuple. If that is not an issue, it would be great if you can merge this.

Reference:
http://www.erlang.org/doc/man/erlang.html#nif_error-1
