### PR TITLE
ARMv7l (RPi Model-B) CFLAGS do not support -m32 flag.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,8 @@
               {"priv/hmac_nif.so", ["c_src/hmac_nif.c"]}]}.
 
 {port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -O3 -I."},
-            {"(?<!-arm)(?<!-armv7l)-[^-]+-linux.*-32$", "CFLAGS", "-m32"},
-            {"(?<!-arm)(?<!-armv7l)-[^-]+-linux.*-32$", "LDFLAGS", "-m32"},
+            {"(?<!-arm|-armv7l)-[^-]+-linux.*-32$", "CFLAGS", "-m32"},
+            {"(?<!-arm|-armv7l)-[^-]+-linux.*-32$", "LDFLAGS", "-m32"},
             {"(?<!-arm)-[^-]+-linux.*-64$", "CFLAGS", "-m64"},
             {"(?<!-arm)-[^-]+-linux.*-64$", "LDFLAGS", "-m64"}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,8 @@
 {port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -O3 -I."},
             {"(?<!-arm|-armv7l)-[^-]+-linux.*-32$", "CFLAGS", "-m32"},
             {"(?<!-arm|-armv7l)-[^-]+-linux.*-32$", "LDFLAGS", "-m32"},
-            {"(?<!-arm)-[^-]+-linux.*-64$", "CFLAGS", "-m64"},
-            {"(?<!-arm)-[^-]+-linux.*-64$", "LDFLAGS", "-m64"}]}.
+            {"(?<!-arm|-armv7l)-[^-]+-linux.*-64$", "CFLAGS", "-m64"},
+            {"(?<!-arm|-armv7l)-[^-]+-linux.*-64$", "LDFLAGS", "-m64"}]}.
 
 {pre_hooks, [{compile, "c_src/config.sh c_src/config.h"},
              {clean, "rm -f c_src/config.h"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,8 @@
               {"priv/hmac_nif.so", ["c_src/hmac_nif.c"]}]}.
 
 {port_env, [{"DRV_CFLAGS", "$DRV_CFLAGS -O3 -I."},
-            {"(?<!-arm)-[^-]+-linux.*-32$", "CFLAGS", "-m32"},
-            {"(?<!-arm)-[^-]+-linux.*-32$", "LDFLAGS", "-m32"},
+            {"(?<!-arm)(?<!-armv7l)-[^-]+-linux.*-32$", "CFLAGS", "-m32"},
+            {"(?<!-arm)(?<!-armv7l)-[^-]+-linux.*-32$", "LDFLAGS", "-m32"},
             {"(?<!-arm)-[^-]+-linux.*-64$", "CFLAGS", "-m64"},
             {"(?<!-arm)-[^-]+-linux.*-64$", "LDFLAGS", "-m64"}]}.
 


### PR DESCRIPTION
If I was to put this in `c_src/config.sh` on 32 bit linux:

    echo "==========================================="
    echo "$CC $CFLAGS -c -o /dev/null $tmpcfile 2>/dev/null"
    echo "==========================================="

I would see 

    =================================
    cc -m32 -c -o /dev/null  2>/dev/null
    =================================

And it now compiles just fine on RPi on ARMv7l.

https://github.com/vinoski/erlsha2/issues/11