### PR TITLE
Use sh instead of bash in config.sh

### DIFF
--- a/c_src/config.sh
+++ b/c_src/config.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 CONFIG_HDR=$1
 


### PR DESCRIPTION
As far as I can tell there's no need to use bash explicitly.

This change allows systems without bash installed to compile
the project.

---

Tested on Linux and FreeBSD, didn't test on OSX.
